### PR TITLE
Feat/634 pre act time of paused mem

### DIFF
--- a/lib/features/mems/list/item/view.dart
+++ b/lib/features/mems/list/item/view.dart
@@ -87,6 +87,11 @@ ListTile _render(
             latestActByMem != null && latestActByMem is ActiveAct;
         final hasPausedAct =
             latestActByMem != null && latestActByMem is PausedAct;
+        final elapsedStart = hasActiveAct
+            ? latestActByMem.period!.start!
+            : hasPausedAct
+                ? latestActByMem.pausedAt!
+                : null;
         final hasEnableMemNotifications = memNotificationEntities
             .where(
               (e) => e is SavedMemNotificationEntityV1 && e.value.isEnabled(),
@@ -123,13 +128,13 @@ ListTile _render(
         );
 
         return ListTile(
-          title: !hasActiveAct
+          title: elapsedStart == null
               ? MemNameText(mem.id)
               : Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Expanded(child: MemNameText(mem.id)),
-                    LiveElapsedTimeText(latestActByMem.period!.start!),
+                    LiveElapsedTimeText(elapsedStart),
                   ],
                 ),
           onTap: onTap,

--- a/lib/features/mems/list/item/view.dart
+++ b/lib/features/mems/list/item/view.dart
@@ -87,11 +87,11 @@ ListTile _render(
             latestActByMem != null && latestActByMem is ActiveAct;
         final hasPausedAct =
             latestActByMem != null && latestActByMem is PausedAct;
-        final elapsedStart = hasActiveAct
-            ? latestActByMem.period!.start!
-            : hasPausedAct
-                ? latestActByMem.pausedAt!
-                : null;
+        final elapsedStart = switch (latestActByMem) {
+          final ActiveAct act => act.period!.start!,
+          final PausedAct act => act.pausedAt!,
+          _ => null,
+        };
         final hasEnableMemNotifications = memNotificationEntities
             .where(
               (e) => e is SavedMemNotificationEntityV1 && e.value.isEnabled(),

--- a/test/presentation/mem_list_item/mem_list_item_test.dart
+++ b/test/presentation/mem_list_item/mem_list_item_test.dart
@@ -216,6 +216,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
+      expect(find.byType(LiveElapsedTimeText), findsOneWidget);
       expect(find.byIcon(Icons.play_arrow), findsNothing);
       expect(find.byIcon(Icons.close), findsNothing);
       expect(find.byIcon(Icons.timer), findsNothing);


### PR DESCRIPTION
## Summary
- Paused の mem でも、リストのタイトルに経過時間を表示する（#634）
- Active は `period.start`、Paused は `pausedAt` を `LiveElapsedTimeText` の開始時刻にする
- 表示フォーマット（`mm:ss` / `hh:mm`）の変更は #635 で行う

## Test plan
- [ ] Active の mem で、開始からの経過時間がこれまで通り表示される
- [ ] Paused の mem で、pause してからの経過時間が表示される
- [ ] Act がない mem では経過時間が表示されない