### PR TITLE
Refactor/347 integrate dateformat

### DIFF
--- a/lib/features/acts/line_chart/line_chart_wrapper.dart
+++ b/lib/features/acts/line_chart/line_chart_wrapper.dart
@@ -1,7 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:mem/features/acts/acts_summary.dart';
 
 class LineChartWrapper extends StatelessWidget {
@@ -67,22 +66,23 @@ class LineChartWrapper extends StatelessWidget {
             final dateTime = DateTime.fromMillisecondsSinceEpoch(
               value.toInt(),
             );
+            final localizations = MaterialLocalizations.of(context);
 
-            DateFormat? formatter;
+            final String text;
             if (value == meta.min || value == meta.max) {
-              formatter = DateFormat.yMd();
+              text = localizations.formatCompactDate(dateTime);
             } else if (meta.axisPosition < meta.parentAxisSize * 0.1 ||
                 meta.parentAxisSize * 0.9 < meta.axisPosition) {
-              formatter = null;
+              text = "";
             } else if (dateTime.day == 1) {
-              formatter = DateFormat.Md();
+              text = localizations.formatShortMonthDay(dateTime);
             } else if (dateTime.day == 10 || dateTime.day == 20) {
-              formatter = DateFormat.d();
+              text = dateTime.day.toString();
+            } else {
+              text = "";
             }
 
-            return Text(
-              formatter?.format(dateTime) ?? "",
-            );
+            return Text(text);
           },
         ),
       ),

--- a/lib/features/mem_notifications/mem_notification.dart
+++ b/lib/features/mem_notifications/mem_notification.dart
@@ -146,6 +146,7 @@ class MemNotification {
   static String? toOneLine(
     Iterable<MemNotification> memNotifications,
     String Function(int weekday) formatWeekday,
+    List<int> weekdayOrder,
     String Function(String at) buildAfterActStartedNotificationText,
     String Function(TimeOfDay time) formatTime,
   ) =>
@@ -164,7 +165,11 @@ class MemNotification {
 
             final text = [
               if (repeatByDayOfWeeks.isNotEmpty)
-                _oneLineRepeatByDaysOfWeek(repeatByDayOfWeeks, formatWeekday),
+                _oneLineRepeatByDaysOfWeek(
+                  repeatByDayOfWeeks,
+                  formatWeekday,
+                  weekdayOrder,
+                ),
               if (afterActStarted != null)
                 _oneLineAfterAct(
                   afterActStarted,
@@ -184,12 +189,13 @@ class MemNotification {
   static String _oneLineRepeatByDaysOfWeek(
     Iterable<MemNotification> repeatByDayOfWeeks,
     String Function(int weekday) formatWeekday,
+    List<int> weekdayOrder,
   ) =>
       v(
         () {
-          return repeatByDayOfWeeks
-              .map((e) => e.time!)
-              .sorted((a, b) => a.compareTo(b))
+          final selected = repeatByDayOfWeeks.map((e) => e.time!).toSet();
+          return weekdayOrder
+              .where(selected.contains)
               .map(formatWeekday)
               .join(", ");
         },

--- a/lib/features/mem_notifications/mem_notification.dart
+++ b/lib/features/mem_notifications/mem_notification.dart
@@ -1,8 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:mem/features/acts/act.dart';
-import 'package:mem/framework/date_and_time/date_and_time.dart';
 import 'package:mem/framework/date_and_time/time_of_day.dart';
 import 'package:mem/features/logger/log_service.dart';
 
@@ -147,7 +145,9 @@ class MemNotification {
 
   static String? toOneLine(
     Iterable<MemNotification> memNotifications,
+    String Function(int weekday) formatWeekday,
     String Function(String at) buildAfterActStartedNotificationText,
+    String Function(TimeOfDay time) formatTime,
   ) =>
       v(
         () {
@@ -164,11 +164,12 @@ class MemNotification {
 
             final text = [
               if (repeatByDayOfWeeks.isNotEmpty)
-                _oneLineRepeatByDaysOfWeek(repeatByDayOfWeeks),
+                _oneLineRepeatByDaysOfWeek(repeatByDayOfWeeks, formatWeekday),
               if (afterActStarted != null)
                 _oneLineAfterAct(
                   afterActStarted,
                   buildAfterActStartedNotificationText,
+                  formatTime,
                 ),
             ].join(", ");
 
@@ -182,16 +183,14 @@ class MemNotification {
 
   static String _oneLineRepeatByDaysOfWeek(
     Iterable<MemNotification> repeatByDayOfWeeks,
+    String Function(int weekday) formatWeekday,
   ) =>
       v(
         () {
-          final dateFormat = DateFormat.E();
-          final firstSunday = DateTime(0, 1, 2);
-
           return repeatByDayOfWeeks
-              .map((e) => firstSunday.add(Duration(days: e.time!)))
+              .map((e) => e.time!)
               .sorted((a, b) => a.compareTo(b))
-              .map((e) => dateFormat.format(e))
+              .map(formatWeekday)
               .join(", ");
         },
         {
@@ -202,9 +201,11 @@ class MemNotification {
   static String _oneLineAfterAct(
     MemNotification afterActStarted,
     String Function(String at) buildAfterActStartedNotificationText,
+    String Function(TimeOfDay time) formatTime,
   ) =>
-      buildAfterActStartedNotificationText(DateFormat(DateFormat.HOUR24_MINUTE)
-          .format(DateAndTime(0, 0, 0, 0, 0, afterActStarted.time)));
+      buildAfterActStartedNotificationText(
+        formatTime(TimeOfDayExt.fromSeconds(afterActStarted.time!)),
+      );
 
   @override
   String toString() => "${super.toString()}: ${{

--- a/lib/features/mem_notifications/mem_notifications_text.dart
+++ b/lib/features/mem_notifications/mem_notifications_text.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mem/features/acts/act.dart';
 import 'package:mem/features/mems/mems_state.dart';
 import 'package:mem/framework/date_and_time/date_time_ext.dart';
+import 'package:mem/framework/date_and_time/weekday.dart';
 import 'package:mem/l10n/l10n.dart';
 import 'package:mem/features/mem_notifications/mem_notification.dart';
 import 'package:mem/features/logger/log_service.dart';
@@ -62,7 +63,7 @@ class _MemNotificationText extends StatelessWidget {
 
           final oneLine = MemNotification.toOneLine(
             enables.map((e) => e.value),
-            (weekday) => localizations.narrowWeekdays[weekday % 7],
+            (weekday) => weekdayLabel(localizations, weekday),
             l10n.afterActStartedNotificationText,
             (time) => time.format(context),
           );

--- a/lib/features/mem_notifications/mem_notifications_text.dart
+++ b/lib/features/mem_notifications/mem_notifications_text.dart
@@ -55,13 +55,16 @@ class _MemNotificationText extends StatelessWidget {
   Widget build(BuildContext context) => v(
         () {
           final l10n = buildL10n(context);
+          final localizations = MaterialLocalizations.of(context);
 
           final enables =
               _memNotificationEntities.where((e) => e.value.isEnabled());
 
           final oneLine = MemNotification.toOneLine(
             enables.map((e) => e.value),
+            (weekday) => localizations.narrowWeekdays[weekday % 7],
             l10n.afterActStartedNotificationText,
+            (time) => time.format(context),
           );
           final nextNotifyAt = MemNotification.nextNotifyAt(
             enables.map((e) => e.value),

--- a/lib/features/mem_notifications/mem_notifications_text.dart
+++ b/lib/features/mem_notifications/mem_notifications_text.dart
@@ -65,6 +65,7 @@ class _MemNotificationText extends StatelessWidget {
           final oneLine = MemNotification.toOneLine(
             enables.map((e) => e.value),
             (weekday) => weekdayLabel(localizations, locale, weekday),
+            weekdaysInLocalizedOrder(localizations),
             l10n.afterActStartedNotificationText,
             (time) => time.format(context),
           );

--- a/lib/features/mem_notifications/mem_notifications_text.dart
+++ b/lib/features/mem_notifications/mem_notifications_text.dart
@@ -57,13 +57,14 @@ class _MemNotificationText extends StatelessWidget {
         () {
           final l10n = buildL10n(context);
           final localizations = MaterialLocalizations.of(context);
+          final locale = Localizations.localeOf(context);
 
           final enables =
               _memNotificationEntities.where((e) => e.value.isEnabled());
 
           final oneLine = MemNotification.toOneLine(
             enables.map((e) => e.value),
-            (weekday) => weekdayLabel(localizations, weekday),
+            (weekday) => weekdayLabel(localizations, locale, weekday),
             l10n.afterActStartedNotificationText,
             (time) => time.format(context),
           );

--- a/lib/features/mem_notifications/mem_repeat_by_day_of_week_notification_view.dart
+++ b/lib/features/mem_notifications/mem_repeat_by_day_of_week_notification_view.dart
@@ -83,6 +83,7 @@ class _MemRepeatByDaysOfWeekNotificationView extends StatelessWidget {
   Widget build(BuildContext context) => v(
         () {
           final localizations = MaterialLocalizations.of(context);
+          final locale = Localizations.localeOf(context);
           final theme = Theme.of(context);
 
           return Padding(
@@ -92,7 +93,7 @@ class _MemRepeatByDaysOfWeekNotificationView extends StatelessWidget {
                   _onChanged(e.map((e) => int.parse(e))),
               days: weekdaysInLocalizedOrder(localizations)
                   .map((weekday) => DayInWeek(
-                        weekdayLabel(localizations, weekday),
+                        weekdayLabel(localizations, locale, weekday),
                         dayKey: weekday.toString(),
                         isSelected: _repeatByDaysOfWeek.contains(weekday),
                       ))

--- a/lib/features/mem_notifications/mem_repeat_by_day_of_week_notification_view.dart
+++ b/lib/features/mem_notifications/mem_repeat_by_day_of_week_notification_view.dart
@@ -74,7 +74,7 @@ class _MemRepeatByDaysOfWeekNotificationView extends StatelessWidget {
   final List<int> _repeatByDaysOfWeek;
   final void Function(Iterable<int> selected) _onChanged;
 
-  _MemRepeatByDaysOfWeekNotificationView(
+  const _MemRepeatByDaysOfWeekNotificationView(
     this._repeatByDaysOfWeek,
     this._onChanged,
   );

--- a/lib/features/mem_notifications/mem_repeat_by_day_of_week_notification_view.dart
+++ b/lib/features/mem_notifications/mem_repeat_by_day_of_week_notification_view.dart
@@ -2,7 +2,6 @@ import 'package:collection/collection.dart';
 import 'package:day_picker/day_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
 import 'package:mem/features/mem_notifications/mem_notification.dart';
 import 'package:mem/features/logger/log_service.dart';
 import 'package:mem/features/mems/detail/states.dart';
@@ -84,9 +83,7 @@ class _MemRepeatByDaysOfWeekNotificationView extends StatelessWidget {
   @override
   Widget build(BuildContext context) => v(
         () {
-          // FIXME ここなんとかならんかな
-          final dateFormat = DateFormat.E();
-          final now = DateTime.now();
+          final localizations = MaterialLocalizations.of(context);
           final theme = Theme.of(context);
 
           return Padding(
@@ -95,11 +92,11 @@ class _MemRepeatByDaysOfWeekNotificationView extends StatelessWidget {
               onSelect: (List<String> e) =>
                   _onChanged(e.map((e) => int.parse(e))),
               days: _daysOfWeek
-                  .map((e) => now.add(Duration(days: e)))
-                  .sorted((a, b) => a.weekday.compareTo(b.weekday))
-                  .mapIndexed((index, e) => DayInWeek(dateFormat.format(e),
-                      dayKey: (index + 1).toString(),
-                      isSelected: _repeatByDaysOfWeek.contains(index + 1)))
+                  .map((weekday) => DayInWeek(
+                        localizations.narrowWeekdays[weekday % 7],
+                        dayKey: weekday.toString(),
+                        isSelected: _repeatByDaysOfWeek.contains(weekday),
+                      ))
                   .toList(growable: false),
               backgroundColor: theme.canvasColor,
               selectedDaysFillColor: theme.primaryColor,

--- a/lib/features/mem_notifications/mem_repeat_by_day_of_week_notification_view.dart
+++ b/lib/features/mem_notifications/mem_repeat_by_day_of_week_notification_view.dart
@@ -6,6 +6,7 @@ import 'package:mem/features/mem_notifications/mem_notification.dart';
 import 'package:mem/features/logger/log_service.dart';
 import 'package:mem/features/mems/detail/states.dart';
 import 'package:mem/features/mem_notifications/mem_notification_entity.dart';
+import 'package:mem/framework/date_and_time/weekday.dart';
 
 const keyMemRepeatByDaysOfWeekNotification =
     Key('mem-repeat-by-days-of-week-notification');
@@ -70,8 +71,6 @@ class MemRepeatByDaysOfWeekNotificationView extends ConsumerWidget {
 }
 
 class _MemRepeatByDaysOfWeekNotificationView extends StatelessWidget {
-  final List<int> _daysOfWeek = [1, 2, 3, 4, 5, 6, 7];
-
   final List<int> _repeatByDaysOfWeek;
   final void Function(Iterable<int> selected) _onChanged;
 
@@ -91,9 +90,9 @@ class _MemRepeatByDaysOfWeekNotificationView extends StatelessWidget {
             child: SelectWeekDays(
               onSelect: (List<String> e) =>
                   _onChanged(e.map((e) => int.parse(e))),
-              days: _daysOfWeek
+              days: weekdaysInLocalizedOrder(localizations)
                   .map((weekday) => DayInWeek(
-                        localizations.narrowWeekdays[weekday % 7],
+                        weekdayLabel(localizations, weekday),
                         dayKey: weekday.toString(),
                         isSelected: _repeatByDaysOfWeek.contains(weekday),
                       ))

--- a/lib/framework/date_and_time/date_and_time.dart
+++ b/lib/framework/date_and_time/date_and_time.dart
@@ -1,5 +1,3 @@
-import 'package:intl/intl.dart';
-
 class DateAndTime extends DateTime {
   bool isAllDay = false;
 
@@ -61,7 +59,7 @@ class DateAndTime extends DateTime {
       );
 
   int get weekNumber {
-    int dayOfYear = int.parse(DateFormat("D").format(this));
+    int dayOfYear = difference(DateTime(year, 1, 1)).inDays + 1;
     return ((dayOfYear - weekday + 10) / 7).floor();
   }
 

--- a/lib/framework/date_and_time/date_and_time.dart
+++ b/lib/framework/date_and_time/date_and_time.dart
@@ -59,7 +59,11 @@ class DateAndTime extends DateTime {
       );
 
   int get weekNumber {
-    int dayOfYear = difference(DateTime(year, 1, 1)).inDays + 1;
+    // local 同士の difference だと DST で inDays がずれる
+    final dayOfYear = DateTime.utc(year, month, day)
+            .difference(DateTime.utc(year, 1, 1))
+            .inDays +
+        1;
     return ((dayOfYear - weekday + 10) / 7).floor();
   }
 

--- a/lib/framework/date_and_time/date_view.dart
+++ b/lib/framework/date_and_time/date_view.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:mem/features/logger/log_service.dart';
 import 'package:mem/framework/view/synced_text_editing_controller.dart';
-
-final DateFormat _dateFormat = DateFormat.yMd();
 
 const _datePickerMaxDuration = Duration(days: 1000000000000000000);
 
@@ -103,7 +100,7 @@ class _DateTextFormFieldState extends State<DateTextFormField> {
           return TextFormField(
             controller: _controller,
             decoration: InputDecoration(
-              hintText: _dateFormat.pattern,
+              hintText: MaterialLocalizations.of(context).dateHelpText,
               suffixIcon: IconButton(
                 onPressed: () => v(
                   () async {

--- a/lib/framework/date_and_time/weekday.dart
+++ b/lib/framework/date_and_time/weekday.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+String weekdayLabel(MaterialLocalizations localizations, int weekday) =>
+    localizations.narrowWeekdays[weekday % 7];
+
+List<int> weekdaysInLocalizedOrder(MaterialLocalizations localizations) {
+  final start = localizations.firstDayOfWeekIndex == 0
+      ? DateTime.sunday
+      : localizations.firstDayOfWeekIndex;
+  return List.generate(7, (i) => (start + i - 1) % 7 + 1);
+}

--- a/lib/framework/date_and_time/weekday.dart
+++ b/lib/framework/date_and_time/weekday.dart
@@ -1,7 +1,26 @@
 import 'package:flutter/material.dart';
 
-String weekdayLabel(MaterialLocalizations localizations, int weekday) =>
-    localizations.narrowWeekdays[weekday % 7];
+const _englishShortWeekdays = [
+  'Sun',
+  'Mon',
+  'Tue',
+  'Wed',
+  'Thu',
+  'Fri',
+  'Sat',
+];
+
+String weekdayLabel(
+  MaterialLocalizations localizations,
+  Locale locale,
+  int weekday,
+) {
+  final index = weekday % 7;
+  if (locale.languageCode == 'en') {
+    return _englishShortWeekdays[index];
+  }
+  return localizations.narrowWeekdays[index];
+}
 
 List<int> weekdaysInLocalizedOrder(MaterialLocalizations localizations) {
   final start = localizations.firstDayOfWeekIndex == 0

--- a/test/components/date_and_time/date_text_form_field_test.dart
+++ b/test/components/date_and_time/date_text_form_field_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:intl/intl.dart';
 import 'package:mem/framework/date_and_time/date_view.dart';
 import 'package:mem/generated/l10n/app_localizations.dart';
 import 'package:mem/l10n/l10n.dart';
@@ -58,7 +57,9 @@ void main() {
           widgetTester
               .widget<TextFormField>(find.byType(TextFormField))
               .initialValue,
-          DateFormat.yMd().format(date),
+          MaterialLocalizations.of(
+            widgetTester.element(find.byType(DateTextFormField)),
+          ).formatCompactDate(date),
         );
       },
     );

--- a/test/components/date_and_time/weekday_test.dart
+++ b/test/components/date_and_time/weekday_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mem/framework/date_and_time/weekday.dart';
+
+void main() {
+  Future<MaterialLocalizations> pumpLocalizations(
+    WidgetTester tester, {
+    required Locale locale,
+  }) async {
+    late MaterialLocalizations localizations;
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: locale,
+        localizationsDelegates: const [
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: [locale],
+        home: Builder(
+          builder: (context) {
+            localizations = MaterialLocalizations.of(context);
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
+    return localizations;
+  }
+
+  testWidgets(
+    'en starts on Sunday',
+    (tester) async {
+      final localizations =
+          await pumpLocalizations(tester, locale: const Locale('en'));
+
+      expect(
+        weekdaysInLocalizedOrder(localizations),
+        [
+          DateTime.sunday,
+          DateTime.monday,
+          DateTime.tuesday,
+          DateTime.wednesday,
+          DateTime.thursday,
+          DateTime.friday,
+          DateTime.saturday,
+        ],
+      );
+      expect(
+        weekdayLabel(localizations, DateTime.monday),
+        localizations.narrowWeekdays[DateTime.monday % 7],
+      );
+    },
+  );
+
+  testWidgets(
+    'de starts on Monday',
+    (tester) async {
+      final localizations =
+          await pumpLocalizations(tester, locale: const Locale('de'));
+
+      expect(
+        weekdaysInLocalizedOrder(localizations),
+        [
+          DateTime.monday,
+          DateTime.tuesday,
+          DateTime.wednesday,
+          DateTime.thursday,
+          DateTime.friday,
+          DateTime.saturday,
+          DateTime.sunday,
+        ],
+      );
+    },
+  );
+}

--- a/test/components/date_and_time/weekday_test.dart
+++ b/test/components/date_and_time/weekday_test.dart
@@ -48,8 +48,16 @@ void main() {
         ],
       );
       expect(
-        weekdayLabel(localizations, DateTime.monday),
-        localizations.narrowWeekdays[DateTime.monday % 7],
+        weekdayLabel(localizations, const Locale('en'), DateTime.monday),
+        'Mon',
+      );
+      expect(
+        weekdayLabel(localizations, const Locale('en'), DateTime.tuesday),
+        'Tue',
+      );
+      expect(
+        weekdayLabel(localizations, const Locale('en'), DateTime.thursday),
+        'Thu',
       );
     },
   );
@@ -71,6 +79,19 @@ void main() {
           DateTime.saturday,
           DateTime.sunday,
         ],
+      );
+    },
+  );
+
+  testWidgets(
+    'ja uses one-character weekdays',
+    (tester) async {
+      final localizations =
+          await pumpLocalizations(tester, locale: const Locale('ja'));
+
+      expect(
+        weekdayLabel(localizations, const Locale('ja'), DateTime.monday),
+        '月',
       );
     },
   );

--- a/test/core/date_and_time_test.dart
+++ b/test/core/date_and_time_test.dart
@@ -54,4 +54,15 @@ void main() {
       );
     },
   );
+
+  group('weekNumber', () {
+    test('uses calendar date, not local duration', () {
+      expect(DateAndTime(2024, 1, 1).weekNumber, 1);
+      expect(DateAndTime(2024, 7, 1).weekNumber, 27);
+      expect(
+        DateAndTime(2024, 7, 1, 23).weekNumber,
+        DateAndTime(2024, 7, 1).weekNumber,
+      );
+    });
+  });
 }

--- a/test/core/mem_notification_test.dart
+++ b/test/core/mem_notification_test.dart
@@ -1,7 +1,6 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:intl/intl.dart';
 import 'package:mem/features/mem_notifications/mem_notification.dart';
-import 'package:mem/framework/date_and_time/date_and_time.dart';
 
 void main() {
   group('MemNotification', () {
@@ -21,8 +20,12 @@ void main() {
     );
 
     group('toOneLine', () {
+      const weekdayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+      String formatWeekday(int weekday) => weekdayNames[weekday % 7];
       String buildAfterActStartedNotificationText(String at) =>
           "after act at $at";
+      String formatTime(TimeOfDay time) =>
+          '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';
 
       test('no enables.', () {
         const memId = 1;
@@ -32,7 +35,9 @@ void main() {
             MemNotification.by(
                 memId, MemNotificationType.repeat, null, "repeat")
           ],
+          (w) => fail("no call"),
           (a) => fail("no call"),
+          (t) => fail("no call"),
         );
 
         expect(oneLine, isNull);
@@ -48,7 +53,9 @@ void main() {
               MemNotification.by(
                   memId, MemNotificationType.repeat, repeatAt, "")
             ],
+            (w) => fail("no call"),
             (a) => fail("no call"),
+            (t) => fail("no call"),
           );
 
           expect(oneLine, isNull);
@@ -66,7 +73,9 @@ void main() {
               MemNotification.by(
                   memId, MemNotificationType.repeatByNDay, repeatByNDay, "")
             ],
+            (w) => fail("no call"),
             (at) => fail("no call"),
+            (t) => fail("no call"),
           );
 
           expect(oneLine, isNull);
@@ -86,7 +95,9 @@ void main() {
               MemNotification.by(
                   memId, MemNotificationType.repeatByDayOfWeek, 1, "")
             ],
+            formatWeekday,
             (at) => fail("no call"),
+            (t) => fail("no call"),
           );
 
           expect(oneLine, equals("Mon"));
@@ -101,7 +112,9 @@ void main() {
             MemNotification.by(memId, MemNotificationType.repeatByDayOfWeek, 2,
                 "repeatByDayOfWeek")
           ],
+          formatWeekday,
           (a) => a,
+          (t) => fail("no call"),
         );
 
         expect(oneLine, equals("Tue"));
@@ -115,14 +128,17 @@ void main() {
             MemNotification.by(
                 memId, MemNotificationType.afterActStarted, time, "")
           ],
+          (w) => fail("no call"),
           buildAfterActStartedNotificationText,
+          formatTime,
         );
 
         expect(
-            oneLine,
-            buildAfterActStartedNotificationText(
-                DateFormat(DateFormat.HOUR24_MINUTE)
-                    .format(DateAndTime(0, 0, 0, 0, 0, time))));
+          oneLine,
+          buildAfterActStartedNotificationText(formatTime(
+            const TimeOfDay(hour: 0, minute: 0),
+          )),
+        );
       });
     });
   });

--- a/test/core/mem_notification_test.dart
+++ b/test/core/mem_notification_test.dart
@@ -21,6 +21,15 @@ void main() {
 
     group('toOneLine', () {
       const weekdayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+      const sundayFirstWeekdays = [
+        DateTime.sunday,
+        DateTime.monday,
+        DateTime.tuesday,
+        DateTime.wednesday,
+        DateTime.thursday,
+        DateTime.friday,
+        DateTime.saturday,
+      ];
       String formatWeekday(int weekday) => weekdayNames[weekday % 7];
       String buildAfterActStartedNotificationText(String at) =>
           "after act at $at";
@@ -36,6 +45,7 @@ void main() {
                 memId, MemNotificationType.repeat, null, "repeat")
           ],
           (w) => fail("no call"),
+          sundayFirstWeekdays,
           (a) => fail("no call"),
           (t) => fail("no call"),
         );
@@ -54,6 +64,7 @@ void main() {
                   memId, MemNotificationType.repeat, repeatAt, "")
             ],
             (w) => fail("no call"),
+            sundayFirstWeekdays,
             (a) => fail("no call"),
             (t) => fail("no call"),
           );
@@ -74,6 +85,7 @@ void main() {
                   memId, MemNotificationType.repeatByNDay, repeatByNDay, "")
             ],
             (w) => fail("no call"),
+            sundayFirstWeekdays,
             (at) => fail("no call"),
             (t) => fail("no call"),
           );
@@ -96,6 +108,7 @@ void main() {
                   memId, MemNotificationType.repeatByDayOfWeek, 1, "")
             ],
             formatWeekday,
+            sundayFirstWeekdays,
             (at) => fail("no call"),
             (t) => fail("no call"),
           );
@@ -113,11 +126,52 @@ void main() {
                 "repeatByDayOfWeek")
           ],
           formatWeekday,
+          sundayFirstWeekdays,
           (a) => a,
           (t) => fail("no call"),
         );
 
         expect(oneLine, equals("Tue"));
+      });
+
+      test('repeat by Sun and Mon follows weekdayOrder.', () {
+        const memId = 1;
+
+        final notifications = [
+          MemNotification.by(memId, MemNotificationType.repeatByDayOfWeek,
+              DateTime.monday, ""),
+          MemNotification.by(memId, MemNotificationType.repeatByDayOfWeek,
+              DateTime.sunday, ""),
+        ];
+
+        expect(
+          MemNotification.toOneLine(
+            notifications,
+            formatWeekday,
+            sundayFirstWeekdays,
+            (a) => fail("no call"),
+            (t) => fail("no call"),
+          ),
+          "Sun, Mon",
+        );
+        expect(
+          MemNotification.toOneLine(
+            notifications,
+            formatWeekday,
+            [
+              DateTime.monday,
+              DateTime.tuesday,
+              DateTime.wednesday,
+              DateTime.thursday,
+              DateTime.friday,
+              DateTime.saturday,
+              DateTime.sunday,
+            ],
+            (a) => fail("no call"),
+            (t) => fail("no call"),
+          ),
+          "Mon, Sun",
+        );
       });
 
       test('after act', () {
@@ -129,6 +183,7 @@ void main() {
                 memId, MemNotificationType.afterActStarted, time, "")
           ],
           (w) => fail("no call"),
+          sundayFirstWeekdays,
           buildAfterActStartedNotificationText,
           formatTime,
         );

--- a/test/presentation/line_chart_wrapper_test.dart
+++ b/test/presentation/line_chart_wrapper_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mem/features/acts/act.dart';
+import 'package:mem/features/acts/acts_summary.dart';
+import 'package:mem/features/acts/line_chart/line_chart_wrapper.dart';
+import 'package:mem/framework/date_and_time/date_and_time.dart';
+import 'package:mem/generated/l10n/app_localizations.dart';
+import 'package:mem/l10n/l10n.dart';
+
+void main() {
+  testWidgets(
+    'formats inner axis dates with month-day and day-of-month',
+    (tester) async {
+      final acts = List.generate(
+        27,
+        (index) {
+          final date = DateAndTime.from(
+            DateTime(2024, 12, 25).add(Duration(days: index)),
+          );
+          return FinishedAct(1, date, date);
+        },
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          onGenerateTitle: (context) => buildL10n(context).test,
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              height: 400,
+              child: LineChartWrapper(
+                ActsSummary(acts, AggregationType.count),
+                (value) => value.toInt().toString(),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final localizations = MaterialLocalizations.of(
+        tester.element(find.byType(LineChartWrapper)),
+      );
+
+      expect(
+        find.text(localizations.formatShortMonthDay(DateTime(2025, 1, 1))),
+        findsOneWidget,
+      );
+      expect(find.text('10'), findsOneWidget);
+    },
+  );
+}

--- a/test/presentation/mem_notifications/mem_notifications_text_test.dart
+++ b/test/presentation/mem_notifications/mem_notifications_text_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mem/features/mem_notifications/mem_notification.dart';
+import 'package:mem/features/mem_notifications/mem_notification_entity.dart';
+import 'package:mem/features/mem_notifications/mem_notifications_text.dart';
+import 'package:mem/features/mems/detail/states.dart';
+import 'package:mem/features/mems/mems_state.dart';
+import 'package:mem/features/settings/preference/keys.dart';
+import 'package:mem/features/settings/preference/preference_key.dart';
+import 'package:mem/features/settings/states.dart';
+import 'package:mem/framework/view/list_value_state_notifier.dart';
+import 'package:mem/generated/l10n/app_localizations.dart';
+import 'package:mem/l10n/l10n.dart';
+
+import '../../entity_factories.dart';
+
+class _FakePreference extends Preference<TimeOfDay> {
+  @override
+  TimeOfDay build(PreferenceKey<TimeOfDay> key) =>
+      const TimeOfDay(hour: 0, minute: 0);
+}
+
+SavedMemNotificationEntityV1 _notification({
+  required int id,
+  required MemNotificationType type,
+  required int time,
+}) {
+  final now = DateTime.now();
+  return savedMemNotification(
+    id: id,
+    memId: 1,
+    type: type,
+    timeOfDaySeconds: time,
+    message: type.name,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+Future<void> _pumpText(
+  WidgetTester tester, {
+  required List<MemNotificationEntityV1> notifications,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        memNotificationsByMemIdProvider(1).overrideWith(
+          (ref) => ListValueStateNotifier(notifications),
+        ),
+        preferenceProvider(startOfDayKey).overrideWith(
+          () => _FakePreference(),
+        ),
+        memEntitiesProvider.overrideWithValue([]),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('en'),
+        onGenerateTitle: (context) => buildL10n(context).test,
+        home: const Scaffold(
+          body: MemNotificationText(1),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('MemNotificationText', () {
+    testWidgets('formats weekdays and after-act time from localizations',
+        (tester) async {
+      await _pumpText(
+        tester,
+        notifications: [
+          _notification(
+            id: 1,
+            type: MemNotificationType.repeatByDayOfWeek,
+            time: DateTime.monday,
+          ),
+          _notification(
+            id: 2,
+            type: MemNotificationType.repeatByDayOfWeek,
+            time: DateTime.sunday,
+          ),
+          _notification(
+            id: 3,
+            type: MemNotificationType.afterActStarted,
+            time: 60 * 60,
+          ),
+        ],
+      );
+
+      final context = tester.element(find.byType(MemNotificationText));
+      final formattedTime =
+          const TimeOfDay(hour: 1, minute: 0).format(context);
+      final l10n = buildL10n(context);
+
+      expect(
+        find.text(
+          'Sun, Mon, ${l10n.afterActStartedNotificationText(formattedTime)}',
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/test/presentation/mem_notifications/mem_repeat_by_day_of_week_notification_view_test.dart
+++ b/test/presentation/mem_notifications/mem_repeat_by_day_of_week_notification_view_test.dart
@@ -1,0 +1,144 @@
+import 'package:day_picker/day_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mem/features/mem_notifications/mem_notification.dart';
+import 'package:mem/features/mem_notifications/mem_notification_entity.dart';
+import 'package:mem/features/mem_notifications/mem_repeat_by_day_of_week_notification_view.dart';
+import 'package:mem/features/mems/detail/states.dart';
+import 'package:mem/framework/view/list_value_state_notifier.dart';
+import 'package:mem/generated/l10n/app_localizations.dart';
+import 'package:mem/l10n/l10n.dart';
+
+import '../../entity_factories.dart';
+
+Widget _buildTestApp(Widget child, {List<Override>? overrides}) {
+  return ProviderScope(
+    overrides: overrides ?? [],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('en'),
+      onGenerateTitle: (context) => buildL10n(context).test,
+      home: Scaffold(
+        body: child,
+      ),
+    ),
+  );
+}
+
+SavedMemNotificationEntityV1 _dayOfWeekNotification({
+  required int? memId,
+  required int weekday,
+}) {
+  final now = DateTime.now();
+  return savedMemNotification(
+    id: weekday,
+    memId: memId,
+    type: MemNotificationType.repeatByDayOfWeek,
+    timeOfDaySeconds: weekday,
+    message: 'Repeat by day of week',
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+Future<ListValueStateNotifier<MemNotificationEntityV1>> _pumpView(
+  WidgetTester tester, {
+  required int? memId,
+  required List<SavedMemNotificationEntityV1> notifications,
+}) async {
+  final listNotifier =
+      ListValueStateNotifier<MemNotificationEntityV1>(notifications);
+  await tester.pumpWidget(
+    _buildTestApp(
+      MemRepeatByDaysOfWeekNotificationView(memId),
+      overrides: [
+        memNotificationsByMemIdProvider(memId)
+            .overrideWith((ref) => listNotifier),
+      ],
+    ),
+  );
+  await tester.pumpAndSettle();
+  return listNotifier;
+}
+
+void main() {
+  group('MemRepeatByDaysOfWeekNotificationView', () {
+    testWidgets('shows English weekday chips from Sunday', (tester) async {
+      await _pumpView(
+        tester,
+        memId: 1,
+        notifications: [
+          _dayOfWeekNotification(memId: 1, weekday: DateTime.monday),
+        ],
+      );
+
+      final selectWeekDays = tester.widget<SelectWeekDays>(
+        find.byType(SelectWeekDays),
+      );
+      expect(
+        selectWeekDays.days.map((e) => e.dayKey),
+        [
+          DateTime.sunday,
+          DateTime.monday,
+          DateTime.tuesday,
+          DateTime.wednesday,
+          DateTime.thursday,
+          DateTime.friday,
+          DateTime.saturday,
+        ].map((weekday) => weekday.toString()),
+      );
+      expect(
+        selectWeekDays.days.map((e) => e.dayName),
+        ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+      );
+      expect(
+        selectWeekDays.days.singleWhere((e) => e.dayKey == '1').isSelected,
+        isTrue,
+      );
+    });
+
+    testWidgets('adds tapped weekday', (tester) async {
+      final listNotifier = await _pumpView(
+        tester,
+        memId: 1,
+        notifications: [
+          _dayOfWeekNotification(memId: 1, weekday: DateTime.monday),
+        ],
+      );
+
+      await tester.tap(find.text('Tue'));
+      await tester.pump();
+
+      expect(
+        listNotifier.state
+            .where((e) => e.value.isRepeatByDayOfWeek())
+            .map((e) => e.value.time),
+        containsAll([DateTime.monday, DateTime.tuesday]),
+      );
+    });
+
+    testWidgets('removes tapped weekday', (tester) async {
+      final listNotifier = await _pumpView(
+        tester,
+        memId: 1,
+        notifications: [
+          _dayOfWeekNotification(memId: 1, weekday: DateTime.monday),
+          _dayOfWeekNotification(memId: 1, weekday: DateTime.tuesday),
+        ],
+      );
+
+      await tester.tap(find.text('Mon'));
+      await tester.pump();
+
+      expect(
+        listNotifier.state
+            .where((e) => e.value.isRepeatByDayOfWeek())
+            .map((e) => e.value.time),
+        [DateTime.tuesday],
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #347

## Summary

- 表示用の `DateFormat` をやめ、日付は `MaterialLocalizations`、時刻は `TimeOfDay.format(context)` に統一した
- 通知1行表示はドメインが文字列を作らず、UI から曜日・時刻の format 関数を渡すようにした
- 曜日チップの並びを `firstDayOfWeekIndex` に合わせた（date picker と同じ。en/ja は日曜始まり）
- `weekNumber` の年内通日計算から `DateFormat("D")` を外した

## Test plan

- [ ] 日付入力の表示と hint が date picker と同じ形式になる
- [ ] 端末を 12/24 時間表示に切り替えて、時刻入力と「開始後」通知テキストが同じ表記になる
- [ ] 曜日繰り返しのチップが locale の週始まり順になる（en/ja は日〜土）
- [ ] Act チャートの横軸日付が画面の日付表示と同じ形式になる